### PR TITLE
Alert for topic search filtering

### DIFF
--- a/vendor/nodebb-theme-harmony-2.1.15/templates/category.tpl
+++ b/vendor/nodebb-theme-harmony-2.1.15/templates/category.tpl
@@ -45,11 +45,17 @@
 	to the category template file directly. It has a placeholder currently for the path
 	that will be used from the backend -->
 <div class="search-inline d-flex align-items-center">
-	<form action="{config.relative_path}/search" method="get" class="d-flex w-100" role="search">
-		<input name="query" type="search" class="form-control" placeholder="[[global:search]]" aria-label="[[search:type-to-search]]" autocomplete="off" />
+	<form action="{config.relative_path}" method="get" class="d-flex w-100" role="search">
+		<input name="search_term" type="search" class="form-control" placeholder="[[global:search]]" aria-label="[[search:type-to-search]]" autocomplete="off" />
 		<button type="submit" class="btn btn-outline-secondary ms-2">[[global:search]]</button>
 	</form>
 </div>
+
+{{{ if search_term }}}
+<div class="alert alert-info" style="margin-bottom: 0px;">
+    Currently Searching for: <strong>{search_term}</strong>
+</div>
+{{{ end }}}
 
 <div class="row flex-fill mt-3">
 	<div class="category d-flex flex-column {{{if widgets.sidebar.length }}}col-lg-9 col-sm-12{{{ else }}}col-lg-12{{{ end }}}">


### PR DESCRIPTION
**Context:**

- Added an alert to be shown when search_term is not null so that the user can clearly see how categories are being filtered using the search bar. 

**Key Requirements**

- Should include indicator that looking at search results and what search term was.

**What was done:**
 
- [X] vendor/nodebb-theme-harmony-2.1.15/templates/category.tpl: Added an alert to be shown after a search bar that is only displayed if search_term is not null.

**Relevant Issues**
#21 

**Testing**

- Ran NodeBB without the if statement to see if the alert would display. 
- Ran NodeBB with the if statement to confirm that no alert is displayed without search query.

**Dependencies**
None

